### PR TITLE
Corriger les erreurs de collision de portée dans les fichiers JSX

### DIFF
--- a/assets/js/app.jsx
+++ b/assets/js/app.jsx
@@ -1,3 +1,4 @@
+(function() {
 const { Alert, AlertDescription, Card, CardContent, CardHeader, CardTitle, Icon } = window.UI
 const EssentialOilCalculator = window.EssentialOilCalculator
 
@@ -77,3 +78,4 @@ const App = () => {
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />)
+})();

--- a/assets/js/calculator.jsx
+++ b/assets/js/calculator.jsx
@@ -1,3 +1,4 @@
+(function() {
 const { useState } = React
 const {
   Card,
@@ -192,3 +193,4 @@ const EssentialOilCalculator = () => {
 }
 
 window.EssentialOilCalculator = EssentialOilCalculator
+})();

--- a/assets/js/forms.jsx
+++ b/assets/js/forms.jsx
@@ -1,3 +1,4 @@
+(function() {
 const { useState } = React
 const {
   Button,
@@ -919,3 +920,4 @@ window.Forms = {
   MultiOilForm,
   ApplicationForm
 }
+})();

--- a/assets/js/results.jsx
+++ b/assets/js/results.jsx
@@ -1,3 +1,4 @@
+(function() {
 const {
   Card,
   CardHeader,
@@ -447,3 +448,4 @@ const CalculationResults = ({ results, onReset }) => {
 }
 
 window.CalculationResults = CalculationResults
+})();

--- a/assets/js/ui.jsx
+++ b/assets/js/ui.jsx
@@ -1,3 +1,4 @@
+(function() {
 const cn = (...inputs) => {
   const classes = []
   inputs.flat(Infinity).forEach((input) => {
@@ -202,3 +203,4 @@ window.UI = {
   Select,
   Icon
 }
+})();


### PR DESCRIPTION
# Corriger les erreurs de collision de portée dans les fichiers JSX

## Summary

Fixes the blank page display issue by wrapping all JSX files in IIFEs (Immediately Invoked Function Expressions) to create isolated scopes. The problem was caused by multiple JSX files declaring the same identifiers (`Button`, `Card`, `Alert`, etc.) using `const` in the global scope, causing "Identifier has already been declared" errors that prevented React from rendering.

**Root cause**: When Babel compiled all JSX files in the browser, they all created const declarations in the same global scope, leading to redeclaration errors.

**Solution**: Wrap each file's content in `(function() { ... })();` to create separate function scopes while preserving all existing functionality and window object exports.

## Review & Testing Checklist for Human

**Critical (must verify):**
- [ ] **Test the actual GitHub Pages deployment** - verify the calculator displays and works on the live GitHub link where the original issue occurred
- [ ] **Complete end-to-end calculator workflow** - test all 3 steps: Individual Parameters → Essential Oil/Multi-Oil selection → Application settings → Results
- [ ] **Browser console check** - ensure no JavaScript errors appear on the deployed version

**Additional verification:**
- [ ] Test multi-oil toggle switch functionality 
- [ ] Verify calculator form submissions and step navigation work correctly
- [ ] Check cross-browser compatibility (Chrome, Firefox, Safari)

### Notes

- All window object exports (`window.UI`, `window.Forms`, `window.EssentialOilCalculator`, `window.CalculationResults`) remain intact
- This is a minimal, surgical fix that doesn't modify any existing application logic
- Local testing confirmed the fix resolves the scope collision errors and restores full functionality
- The application uses React with Babel standalone compilation, which is why this IIFE approach was necessary

**Session info**: Requested by @codeExplorer42647 | [Devin session](https://app.devin.ai/sessions/4424758c193b487ebfce5afe85832b0c)

![Local testing screenshot](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org-94059bcf986f493ba7492b299061ba83/07811ccc-25fa-4c24-a2d2-74245e7f4f6b?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT7SCDAD4CP%2F20251005%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20251005T091743Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjENr%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQDFQASXgr2IXV9K7O3NY3CIYsN%2BvgHSkq8yvV2AdH%2FXiwIgP68YXbrgMe2pwRQAkHsAyJlYwipPEAnt2rzV8mVzV6gqtwUIchABGgwyNzI1MDY0OTgzMDMiDIwv9glkuI8cq3OgHSqUBQt82v3Ro1dAu%2FIj%2FVNL68X3mreV%2B0B0IdAVYh714sRMwUKMaDq%2FeNothJ%2Fppx6TGxMpJAiu81VMOovAfSDZBFkovNw46fPsDIKXZLRNShF47Ty2aVSkNL5z1M7M5CVOozXLBAsjbjfuJg92ZGcJN7PmazqzImtdPGntqQdtjItbygFu8rg3QUWk8TXNnXcfXqbFt97egB4AX3dMm7giPuQzmnywwCKL9sYm%2B3wkSHL23UiK65RHDHp8Ux4tUUFgFG3hgBvIOvbOOpL%2FDQTWYoI0%2FBiVb4lic7GxvkZEt%2Fh2p9olnBIb%2F4ekFp8DXlQpnIBAJq1GGmjmJTV6B6oB3BoGSBhXyQM9nHx05a8npWPIZxiOW0XdLXkYxa22%2B0LquDl1qA1%2FXxWOCERh7d9vRwMyixyIP%2FHvt1eAL%2BqIVZhE9D0mIyeASWqgNKe9Z7xp%2BUs7uhBJVnikwvvZR1amY7ZZ9W6DJKCnBpL1tDGNzPJRShoTaxQI2KPAw0ah%2BA3T1hwzLPFGU5ONDcnpeQgm7OV2SyZkhG2tEwPdF9slWYwT%2Fe11TWFM6pjni%2B72WJEnFiTstXjkCS8XOG%2FqVamI8N%2Fxx3zyhHN8EJ8aWBexsFEFNvdY0tm4z5UMWZ9rEf8RXShPF9MoXLj01sYI6WkHd8lqnk02rlirPXa5QIDls7XrP2fC8q88XoBlgtexp%2Fj5CrWtxVS9sreYhpdW9c14Ym1CF9Re412rvSM4wQUrI8ke%2FqeH0DbMW80fd2iwFv7kH%2BDjxm6c%2FQmk%2FiFhRi%2BW8zcnNBxM2EBs6s3FvSFKVR%2FRA1QiX2iMg6wG5F1boU0s01WO0RNNMZkBOlnD8REhfHcGxO5dYpqCHZckSTOSOq06AkNY9jDT64jHBjqYAU0fN1rzo%2FbunajHE9dUIKdZ7MdIspmmfzJ1q7XNH%2BzrY0yYrLpdv4vhrg%2Fi4%2FBk6VgPro%2ByjRwuqzMkTVIrRdYVR56wJniKcFQslnPFMUKu%2BseR0uEw5Ab3ALDenUnBX2OZYoCc5RskwtwoJw8O4VItgGjvyCNXTSvCjSgvF%2FyxLK10LdmujRHskeIb7Eu1RomAFhfpcTlC&X-Amz-Signature=6b18971158cc8d5663f3adcc32c3e31b63f7a5b2dbbb15c937fc0e8b3abdeb7d)