### PR TITLE
Corriger l'affichage des erreurs de validation à l'étape 3

### DIFF
--- a/assets/js/calculator.jsx
+++ b/assets/js/calculator.jsx
@@ -17,6 +17,29 @@ const CalculationResults = window.CalculationResults
 
 const apiUrl = 'https://app-ggdmpfbn.fly.dev'
 
+const formatApiError = (errorData) => {
+  if (!errorData || !errorData.detail) {
+    return 'Erreur de calcul'
+  }
+  
+  if (Array.isArray(errorData.detail)) {
+    const messages = errorData.detail
+      .map(err => err.msg || err.message || String(err))
+      .filter(msg => msg)
+    return messages.length > 0 ? messages.join('; ') : 'Erreur de validation'
+  }
+  
+  if (typeof errorData.detail === 'object' && errorData.detail.msg) {
+    return errorData.detail.msg
+  }
+  
+  if (typeof errorData.detail === 'string') {
+    return errorData.detail
+  }
+  
+  return 'Erreur de calcul'
+}
+
 const EssentialOilCalculator = () => {
   const [currentStep, setCurrentStep] = useState(1)
   const [isCalculating, setIsCalculating] = useState(false)
@@ -64,7 +87,7 @@ const EssentialOilCalculator = () => {
 
       if (!response.ok) {
         const errorData = await response.json()
-        throw new Error(errorData.detail || 'Erreur de calcul')
+        throw new Error(formatApiError(errorData))
       }
 
       const result = await response.json()


### PR DESCRIPTION
# Corriger l'affichage des erreurs de validation à l'étape 3

## Summary

Fixes the error display bug where API validation errors at step 3 were shown as "Erreur : [object Object],[object Object]" instead of readable error messages.

**Root cause**: FastAPI returns validation errors as an array of objects (standard Pydantic format), but the error handling code was converting this array directly to a string, resulting in JavaScript's default "[object Object]" conversion.

**Solution**: Added `formatApiError()` helper function that:
- Detects if `errorData.detail` is an array of error objects
- Extracts the `msg` field from each error object  
- Joins multiple error messages with "; " separator for readability
- Handles fallback cases (single object, string, null/undefined)

## Review & Testing Checklist for Human

**⚠️ CRITICAL - Must test the actual error scenario (1 item):**

- [ ] **Trigger validation errors at step 3**: Fill out steps 1-2 normally, then at step 3 try submitting with invalid data (empty fields, negative numbers, etc.) to reproduce the original "[object Object],[object Object]" error and verify it now shows readable error messages

**🟡 MEDIUM - Verify no regressions (2 items):**

- [ ] **End-to-end normal flow**: Complete all 4 calculator steps with valid data to ensure the change doesn't break successful calculations
- [ ] **Browser console check**: Verify no new JavaScript errors appear during both normal and error scenarios

### Notes

**Important**: This fix was written based on analyzing the error pattern but the actual error scenario has not been tested yet. The normal flow was verified to work, but triggering real validation errors is needed to confirm the fix works correctly.

The `formatApiError` function handles multiple error response formats with graceful fallbacks, but relies on assumptions about the FastAPI/Pydantic error structure that should be validated through testing.

**Requested by**: @codeExplorer42647 (nolan.lidy.sa@gmail.com)  
**Link to Devin run**: https://app.devin.ai/sessions/4424758c193b487ebfce5afe85832b0c